### PR TITLE
Initialize docgen pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -r requirements.txt
+      - run: flake8
+      - run: isort --check --diff .
+      - run: mypy
+      - run: pytest -q
+      - run: docker build -t docgen-pipeline .
+      - uses: docker/login-action@v2
+        if: github.ref == 'refs/heads/main'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - run: docker push ghcr.io/${{ github.repository }}:latest
+        if: github.ref == 'refs/heads/main'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "api.dispatcher:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,11 @@
+from .brd_agent import BrdAgent
+from .figma_agent import FigmaAgent
+from .solution_agent import SolutionAgent
+from .story_agent import StoryAgent
+
+__all__ = [
+    "BrdAgent",
+    "SolutionAgent",
+    "FigmaAgent",
+    "StoryAgent",
+]

--- a/agents/base.py
+++ b/agents/base.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import asyncio
+from abc import ABC, abstractmethod
+from functools import wraps
+from typing import Callable, TypeVar
+
+from schemas import AgentResult, UploadPayload
+
+F = TypeVar("F", bound=Callable)
+
+
+def retry(max_attempts: int = 3, base_delay: float = 0.5) -> Callable[[F], F]:
+    def decorator(func: F) -> F:
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            attempt = 0
+            delay = base_delay
+            while True:
+                try:
+                    return await func(*args, **kwargs)
+                except Exception:
+                    attempt += 1
+                    if attempt >= max_attempts:
+                        raise
+                    await asyncio.sleep(delay)
+                    delay *= 2
+        return wrapper  # type: ignore
+
+    return decorator
+
+
+class BaseAgent(ABC):
+    name: str
+
+    @abstractmethod
+    async def run(self, payload: UploadPayload) -> AgentResult:
+        ...
+
+    async def execute(self, payload: UploadPayload) -> AgentResult:
+        @retry()
+        async def _run() -> AgentResult:
+            return await self.run(payload)
+
+        return await _run()

--- a/agents/brd_agent.py
+++ b/agents/brd_agent.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+from schemas import AgentResult, ArtefactType, UploadPayload
+
+from .base import BaseAgent
+
+
+class BrdAgent(BaseAgent):
+    name = "brd"
+
+    async def run(self, payload: UploadPayload) -> AgentResult:
+        output_dir = payload.output_dir or Path("output")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        loader = FileSystemLoader(Path(__file__).parent.parent / "prompts")
+        env = Environment(loader=loader)
+        template = env.get_template("brd_prompt.jinja2")
+        content = template.render(
+            project_name=payload.project_name,
+            description=payload.description,
+        )
+        path = output_dir / "BRD.md"
+        path.write_text(content)
+        return AgentResult(artefact_type=ArtefactType.BRD, path=path)

--- a/agents/figma_agent.py
+++ b/agents/figma_agent.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+from schemas import AgentResult, ArtefactType, UploadPayload
+
+from .base import BaseAgent
+
+
+class FigmaClient:
+    async def create_project(self, payload: UploadPayload) -> Tuple[str, str]:
+        return "https://figma.example/file", "https://figma.example/prototype"
+
+
+class FigmaAgent(BaseAgent):
+    name = "figma"
+
+    def __init__(self, client: FigmaClient | None = None) -> None:
+        self.client = client or FigmaClient()
+
+    async def run(self, payload: UploadPayload) -> AgentResult:
+        output_dir = payload.output_dir or Path("output")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        file_url, prototype_url = await self.client.create_project(payload)
+        data = {"file_url": file_url, "prototype_url": prototype_url}
+        path = output_dir / "figma.json"
+        path.write_text(str(data))
+        return AgentResult(artefact_type=ArtefactType.FIGMA, path=path)

--- a/agents/solution_agent.py
+++ b/agents/solution_agent.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+from schemas import AgentResult, ArtefactType, UploadPayload
+
+from .base import BaseAgent
+
+
+class SolutionAgent(BaseAgent):
+    name = "solution"
+
+    async def run(self, payload: UploadPayload) -> AgentResult:
+        output_dir = payload.output_dir or Path("output")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        loader = FileSystemLoader(Path(__file__).parent.parent / "prompts")
+        env = Environment(loader=loader)
+        template = env.get_template("solution_prompt.jinja2")
+        content = template.render(
+            project_name=payload.project_name,
+            description=payload.description,
+        )
+        path = output_dir / "Solution.md"
+        path.write_text(content)
+        return AgentResult(artefact_type=ArtefactType.SOLUTION, path=path)

--- a/agents/story_agent.py
+++ b/agents/story_agent.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from jinja2 import Environment, FileSystemLoader
+
+from schemas import AgentResult, ArtefactType, UploadPayload
+
+from .base import BaseAgent
+
+
+class JiraClient:
+    async def create_stories(self, yaml_path: Path) -> None:
+        return None
+
+
+class StoryAgent(BaseAgent):
+    name = "story"
+
+    def __init__(self, jira: JiraClient | None = None) -> None:
+        self.jira = jira or JiraClient()
+
+    async def run(self, payload: UploadPayload) -> AgentResult:
+        output_dir = payload.output_dir or Path("output")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        loader = FileSystemLoader(Path(__file__).parent.parent / "prompts")
+        env = Environment(loader=loader)
+        template = env.get_template("story_prompt.jinja2")
+        content = template.render(
+            project_name=payload.project_name,
+            description=payload.description,
+        )
+        path = output_dir / "epics_userstories.yaml"
+        yaml_data = yaml.safe_load(content)
+        path.write_text(yaml.safe_dump(yaml_data))
+        await self.jira.create_stories(path)
+        return AgentResult(artefact_type=ArtefactType.BACKLOG, path=path)

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+from .dispatcher import router
+
+app = FastAPI()
+app.include_router(router)
+
+__all__ = ["app"]

--- a/api/dispatcher.py
+++ b/api/dispatcher.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from pathlib import Path
+
+from fastapi import APIRouter, FastAPI
+
+from agents import BrdAgent, FigmaAgent, SolutionAgent, StoryAgent
+from schemas import AgentResult, UploadPayload
+
+router = APIRouter()
+app = FastAPI()
+app.include_router(router)
+
+
+def timestamp_dir() -> Path:
+    ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    out = Path("output") / ts
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+@router.post("/generate")
+async def generate(payload: UploadPayload) -> list[AgentResult]:
+    out_dir = timestamp_dir()
+    payload.output_dir = out_dir
+    agents = [BrdAgent(), SolutionAgent(), FigmaAgent(), StoryAgent()]
+    results = await asyncio.gather(*(a.execute(payload) for a in agents))
+    github = GitHubClient()
+    await github.create_pr(out_dir)
+    return results
+
+
+class GitHubClient:
+    async def create_pr(self, path: Path) -> str:
+        return "https://github.com/example/pr"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.9"
+services:
+  app:
+    build: .
+    ports:
+      - "8000:8000"
+    depends_on:
+      - redis
+  redis:
+    image: redis:alpine

--- a/prompts/brd_prompt.jinja2
+++ b/prompts/brd_prompt.jinja2
@@ -1,0 +1,3 @@
+# {{ project_name }} BRD
+
+{{ description }}

--- a/prompts/figma_prompt.jinja2
+++ b/prompts/figma_prompt.jinja2
@@ -1,0 +1,1 @@
+Create a Figma design for {{ project_name }}.

--- a/prompts/solution_prompt.jinja2
+++ b/prompts/solution_prompt.jinja2
@@ -1,0 +1,3 @@
+# {{ project_name }} Solution
+
+{{ description }} solution details

--- a/prompts/story_prompt.jinja2
+++ b/prompts/story_prompt.jinja2
@@ -1,0 +1,5 @@
+project: {{ project_name }}
+epics:
+  - example_epic
+user_stories:
+  - as a user, I want {{ description }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+fastapi
+uvicorn
+jinja2
+PyYAML
+pydantic
+pytest
+pytest-asyncio
+flake8
+isort
+mypy

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class ArtefactType(str, Enum):
+    BRD = "BRD"
+    SOLUTION = "SOLUTION"
+    FIGMA = "FIGMA"
+    BACKLOG = "BACKLOG"
+
+
+class UploadPayload(BaseModel):
+    project_name: str = Field(..., min_length=1)
+    description: str = Field(..., min_length=1)
+    output_dir: Optional[Path] = None
+
+
+class AgentResult(BaseModel):
+    artefact_type: ArtefactType
+    path: Path
+
+    class Config:
+        json_encoders = {Path: str}

--- a/scripts/bootstrap_repo.py
+++ b/scripts/bootstrap_repo.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def main() -> None:
+    env = Path(".env.sample")
+    if not env.exists():
+        env.write_text("PROJECT_NAME=sample\nDESCRIPTION=sample description\n")
+    out = Path("output")
+    out.mkdir(exist_ok=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,51 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from agents import (  # noqa: E402
+    BrdAgent,
+    FigmaAgent,
+    SolutionAgent,
+    StoryAgent,
+)
+
+from agents.figma_agent import FigmaClient  # noqa: E402
+from agents.story_agent import JiraClient  # noqa: E402
+from schemas import ArtefactType, UploadPayload  # noqa: E402
+
+
+class DummyFigma(FigmaClient):
+    async def create_project(self, payload: UploadPayload):
+        return "file", "prototype"
+
+
+class DummyJira(JiraClient):
+    async def create_stories(self, yaml_path: Path):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_agents(tmp_path: Path):
+    payload = UploadPayload(
+        project_name="Test",
+        description="Desc",
+        output_dir=tmp_path,
+    )
+    figma = FigmaAgent(DummyFigma())
+    jira = StoryAgent(DummyJira())
+    agents = [BrdAgent(), SolutionAgent(), figma, jira]
+    results = await asyncio.gather(*(a.execute(payload) for a in agents))
+    types = {r.artefact_type for r in results}
+    expected = {
+        ArtefactType.BRD,
+        ArtefactType.SOLUTION,
+        ArtefactType.FIGMA,
+        ArtefactType.BACKLOG,
+    }
+    assert types == expected
+    for r in results:
+        assert r.path.exists()


### PR DESCRIPTION
## Summary
- setup FastAPI dispatcher and base agents
- implement specialized agents for BRD, solution, Figma, and backlog
- add schemas, prompts, and unit tests
- provide Docker setup and GitHub Actions CI
- include helper bootstrap script

## Testing
- `python -m flake8`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687032aec7ac832984ec3a5ceca00970