### PR TITLE
Explain API hosting and enable CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Before publishing the site you should replace the placeholder value in `frontend
 "homepage": "https://<your-username>.github.io/DocPipe/"
 ```
 
-The Vite configuration already sets `base: '/DocPipe/'` so the app loads correctly from the Pages URL.
+The Vite configuration already sets `base: '/DocPipe/'` so the app loads correctly from the Pages URL. Remember that GitHub Pages is **static hosting only**. You must run the FastAPI backend elsewhere (for example on a cloud VM or PaaS) and expose it over HTTPS. Set `VITE_API_URL` in `frontend/.env` to point at this backend so the React app can POST to `/generate`.
 
 ### Type Checking
 

--- a/api/dispatcher.py
+++ b/api/dispatcher.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import cast
 
 from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 
 from agents import BrdAgent, FigmaAgent, SolutionAgent, StoryAgent
 from schemas import AgentResult, UploadPayload
@@ -15,6 +16,12 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.include_router(router)
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ Client (React) ---> /generate (FastAPI) ---> Agents ---> Output files
    ```
 
 The API will listen on `localhost:8000` by default. The frontend expects the API on the same origin unless `VITE_API_URL` is set.
+When the React app is hosted separately (e.g. on GitHub Pages) you must deploy the FastAPI service elsewhere and expose it over HTTPS. Set `VITE_API_URL` to this public endpoint so the POST request to `/generate` succeeds. The API includes CORS middleware allowing requests from any origin by default.
 
 ### Docker Compose
 


### PR DESCRIPTION
## Summary
- document that GitHub Pages only hosts the frontend
- advise configuring `VITE_API_URL` when deploying the app
- allow cross‑origin requests in the FastAPI app with `CORSMiddleware`

## Testing
- `pytest -q`
- `mypy`

------
https://chatgpt.com/codex/tasks/task_e_6870707e1984832995a48f9d3b09808d