### PR TITLE
Add Salesforce UI demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Documentation generation Pipeline
 ## Documentation
 
 Full usage and architecture details are provided in [docs/README.md](docs/README.md). Any contributor, human or AI, should ensure the documentation stays in sync with the codebase. See [docs/AI_GUIDELINES.md](docs/AI_GUIDELINES.md) for agent specific guidance.
+A demo output is available under [docs/salesforce_demo](docs/salesforce_demo/README.md) and is also viewable from the "Example" tab of the deployed frontend.
 
 ## Frontend
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,10 @@ Static type checking is configured via `mypy`:
 mypy
 ```
 
+## Example Output
+A set of mocked artefacts generated for a Salesforce UI component can be found in [docs/salesforce_demo](salesforce_demo/README.md). The same demo is presented in the frontend under the "Example" tab so visitors know what to expect.
+
+
 ## Directory Layout
 
 - `agents/` – asynchronous worker classes responsible for artefact creation.

--- a/docs/salesforce_demo/README.md
+++ b/docs/salesforce_demo/README.md
@@ -1,0 +1,20 @@
+# Salesforce Custom UI Demo
+
+This folder contains a small preview of DocPipe in action. The example assumes a request to generate documentation for a custom Salesforce component used to manage leads more efficiently. The output below was produced using the included agents with dummy data.
+
+## Workflow
+1. The React frontend submits a `POST /generate` request with a project name and description.
+2. `dispatcher.py` creates a timestamped folder and sequentially executes all agents:
+   - **BrdAgent**
+   - **SolutionAgent**
+   - **FigmaAgent**
+   - **StoryAgent**
+3. Each agent writes its artefact to the same output directory.
+4. The results are returned to the frontend and could be pushed to GitHub or Jira.
+
+## Generated Artefacts
+- [`BRD.md`](output/BRD.md)
+- [`Solution.md`](output/Solution.md)
+- [`figma.json`](output/figma.json)
+- [`epics_userstories.yaml`](output/epics_userstories.yaml)
+

--- a/docs/salesforce_demo/output/BRD.md
+++ b/docs/salesforce_demo/output/BRD.md
@@ -1,0 +1,3 @@
+# Salesforce Custom UI BRD
+
+Create a custom UI component for salesforce to manage leads efficiently

--- a/docs/salesforce_demo/output/Solution.md
+++ b/docs/salesforce_demo/output/Solution.md
@@ -1,0 +1,3 @@
+# Salesforce Custom UI Solution
+
+Create a custom UI component for salesforce to manage leads efficiently solution details

--- a/docs/salesforce_demo/output/epics_userstories.yaml
+++ b/docs/salesforce_demo/output/epics_userstories.yaml
@@ -1,0 +1,5 @@
+epics:
+- example_epic
+project: Salesforce Custom UI
+user_stories:
+- as a user, I want Create a custom UI component for salesforce to manage leads efficiently

--- a/docs/salesforce_demo/output/figma.json
+++ b/docs/salesforce_demo/output/figma.json
@@ -1,0 +1,1 @@
+{'file_url': 'https://figma.example/file', 'prototype_url': 'https://figma.example/prototype'}

--- a/frontend/public/demo/BRD.md
+++ b/frontend/public/demo/BRD.md
@@ -1,0 +1,3 @@
+# Salesforce Custom UI BRD
+
+Create a custom UI component for salesforce to manage leads efficiently

--- a/frontend/public/demo/Solution.md
+++ b/frontend/public/demo/Solution.md
@@ -1,0 +1,3 @@
+# Salesforce Custom UI Solution
+
+Create a custom UI component for salesforce to manage leads efficiently solution details

--- a/frontend/public/demo/epics_userstories.yaml
+++ b/frontend/public/demo/epics_userstories.yaml
@@ -1,0 +1,5 @@
+epics:
+- example_epic
+project: Salesforce Custom UI
+user_stories:
+- as a user, I want Create a custom UI component for salesforce to manage leads efficiently

--- a/frontend/public/demo/figma.json
+++ b/frontend/public/demo/figma.json
@@ -1,0 +1,1 @@
+{'file_url': 'https://figma.example/file', 'prototype_url': 'https://figma.example/prototype'}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -23,6 +23,19 @@ button {
   font-size: 1rem;
 }
 
+nav.tabs {
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.demo pre {
+  background: #f7f7f7;
+  padding: 0.5rem;
+  overflow-x: auto;
+}
+
+
 .results ul {
   list-style: none;
   padding: 0;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,12 @@
 import { useState } from 'react'
+import Demo from './Demo'
 import './App.css'
 
 function App() {
   const [form, setForm] = useState({ project_name: '', description: '' })
   const [results, setResults] = useState(null)
   const [loading, setLoading] = useState(false)
+  const [view, setView] = useState('generate')
 
   const handleChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value })
@@ -45,26 +47,36 @@ function App() {
   return (
     <div className="container">
       <h1>DocPipe</h1>
-      <form onSubmit={submit}>
-        <input
-          name="project_name"
-          placeholder="Project Name"
-          value={form.project_name}
-          onChange={handleChange}
-          required
-        />
-        <textarea
-          name="description"
-          placeholder="Description"
-          value={form.description}
-          onChange={handleChange}
-          required
-        />
-        <button type="submit" disabled={loading}>
-          {loading ? 'Generating...' : 'Generate Docs'}
+      <nav className="tabs">
+        <button onClick={() => setView('generate')} disabled={view==='generate'}>
+          Generate
         </button>
-      </form>
-      {results && (
+        <button onClick={() => setView('demo')} disabled={view==='demo'}>
+          Example
+        </button>
+      </nav>
+      {view === 'generate' && (
+        <form onSubmit={submit}>
+          <input
+            name="project_name"
+            placeholder="Project Name"
+            value={form.project_name}
+            onChange={handleChange}
+            required
+          />
+          <textarea
+            name="description"
+            placeholder="Description"
+            value={form.description}
+            onChange={handleChange}
+            required
+          />
+          <button type="submit" disabled={loading}>
+            {loading ? 'Generating...' : 'Generate Docs'}
+          </button>
+        </form>
+      )}
+      {view === 'generate' && results && (
         <div className="results">
           <h2>Results</h2>
           {Array.isArray(results) ? (
@@ -88,6 +100,7 @@ function App() {
           )}
         </div>
       )}
+      {view === 'demo' && <Demo />}
     </div>
   )
 }

--- a/frontend/src/Demo.jsx
+++ b/frontend/src/Demo.jsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react'
+
+function Demo() {
+  const [docs, setDocs] = useState({})
+  const base = import.meta.env.BASE_URL || '/'
+
+  useEffect(() => {
+    const load = async (file, key) => {
+      const resp = await fetch(`${base}demo/${file}`)
+      const text = await resp.text()
+      return [key, text]
+    }
+    Promise.all([
+      load('BRD.md', 'brd'),
+      load('Solution.md', 'solution'),
+      load('epics_userstories.yaml', 'backlog'),
+      load('figma.json', 'figma'),
+    ]).then((items) => {
+      const obj = {}
+      items.forEach(([k, v]) => (obj[k] = v))
+      setDocs(obj)
+    })
+  }, [base])
+
+  return (
+    <div className="demo">
+      <h2>Salesforce UI Example</h2>
+      <p>
+        Below is a set of mocked artefacts produced by DocPipe for a sample
+        Salesforce custom UI component. These files are also available in the
+        repository under <code>docs/salesforce_demo</code>.
+      </p>
+      <section>
+        <h3>Business Requirement Document</h3>
+        <pre>{docs.brd}</pre>
+      </section>
+      <section>
+        <h3>Solution Outline</h3>
+        <pre>{docs.solution}</pre>
+      </section>
+      <section>
+        <h3>Backlog</h3>
+        <pre>{docs.backlog}</pre>
+      </section>
+      <section>
+        <h3>Figma Links</h3>
+        <pre>{docs.figma}</pre>
+      </section>
+    </div>
+  )
+}
+
+export default Demo


### PR DESCRIPTION
## Summary
- document a demo under `docs/salesforce_demo`
- link to the demo from the main README files
- include BRD, solution, Figma placeholder and backlog examples
- add demo to the frontend so the example is visible on GitHub Pages
- remove binary image files to allow PR creation

## Testing
- `pip install jinja2 pyyaml pytest-asyncio`
- `pytest -q`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687121c512608329b31196d3509d4d9a